### PR TITLE
Fix for missing URI in Add-ContentLibrary

### DIFF
--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -1946,9 +1946,9 @@ Function Add-ContentLibrary {
                 if ($datastoreExist = Get-Datastore -Name $datastore -ErrorAction SilentlyContinue | Where-Object {$_.Name -eq $datastore}) {
 
                     #attribution to William Lam (https://gist.github.com/lamw/988e4599c0f88d9fc25c9f2af8b72c92) for this snippet
-                    Invoke-RestMethod -Uri $contentLibraryUrl -Method Get | Out-Null
+                    Invoke-RestMethod -Uri $subscriptionUrl -Method Get | Out-Null
 
-                    $endpointRequest = [System.Net.Webrequest]::Create("$contentLibraryUrl")
+                    $endpointRequest = [System.Net.Webrequest]::Create("$subscriptionUrl")
                     $sslThumbprint = $endpointRequest.ServicePoint.Certificate.GetCertHashString()
                     $sslThumbprint = $sslThumbprint -replace '(..(?!$))', '$1:'
 


### PR DESCRIPTION
Updated variable $contentLibraryUrl to $subscriptionUrl to fix the following error message when running the Add-ContentLibrary command.
Error at script line 1949
Relevant Command: Invoke-RestMethod -uri $contentLibraryUrl -method Get | Out-null
Error Message: Cannot validate argument on parameter 'uri'. The argument is null or empty. Provide an argument that is not null or empty, and then try the command again
Signed-off-by: stuart_tormey <stuart_tormey@hotmail.co.uk>