### PR TITLE
Fix for Set-vCenterPermission

### DIFF
--- a/PowerValidatedSolutions.psm1
+++ b/PowerValidatedSolutions.psm1
@@ -2615,7 +2615,7 @@ Function Set-vCenterPermission {
 			$objectCheck = Get-VIPermission -Server $vcenter.fqdn | Where-Object { $_.Principal -eq $principal }
             if ($objectCheck) {
                 if (!($objectCheck.Role -eq $role)) {
-                    New-VIPermission -Server $vcenter.fqdn -Role $role -Principal $principal -Entity (Get-Folder "Datacenters" -Type Datacenter | Where-Object {$_.Uid -like "*"+$workloadDomain+"*"}) | Out-Null
+                    New-VIPermission -Server $vcenter.fqdn -Role $role -Principal $principal -Entity (Get-Folder "Datacenters" -Type Datacenter | Where-Object {$_.Uid -like "*"+$vcenter.fqdn+"*"}) | Out-Null
                     $objectCheck = Get-VIPermission -Server $vcenter.fqdn | Where-Object { $_.Principal -eq $principal }
                     if ($objectCheck.Role -eq $role) {
                         Write-Output "Assigned $role permission to $principal Successfully"


### PR DESCRIPTION
Updated variable as when using a workload domain name that does not match anything within the fqdn of the vcsa, the command will not work with the following error.
Error at Script Line 2618
Relevant Command: New-VIPermission -Server $vcenter.fqdn -Role $role -Principal $principal -Entity (Get-Folder "Datacenters" -Type Datacenter | Where-Object {$_.Uid -like "*"+$workloaddomain+"*"}) | Out-Null
Error Message: Cannot process argument transformation on parameter 'Entity'. Object reference not set to an instance of an object.

An example would be a domain name of "management" and a fqdn of "vcsa-01.mydomain.local", thiscauses the like statement to fail.

If you run Get-Folder "Datacenters" -Type Datacenter | fl the UID is as per the following
 /VIServer=vsphere.local\administrator@<my redacted fqdn>:443/Folder=Folder-group-d1/

If you change it to use the vCenter FQDN instead of the workload domain name it will run regardless of the name of the workload domain.
Signed Stuart_tormey@hotmail.co.uk